### PR TITLE
Upgrade the version of isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,12 +3,8 @@ repos:
     rev: 3.8.3
     hooks:
       - id: flake8
-  - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.2.0
-    hooks:
-      - id: seed-isort-config
-  - repo: https://github.com/timothycrosley/isort
-    rev: 4.3.21
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
     hooks:
       - id: isort
   - repo: https://github.com/pre-commit/mirrors-yapf

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ split_before_expression_after_opening_paren = true
 [isort]
 line_length = 79
 multi_line_output = 0
-known_standard_library = pkg_resources,setuptools,logging,os,warnings,abc
+extra_standard_library = pkg_resources,setuptools,logging,os,warnings,abc
 known_third_party =yaml
 no_lines_before = STDLIB,LOCALFOLDER
 default_section = THIRDPARTY

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,6 @@ split_before_expression_after_opening_paren = true
 line_length = 79
 multi_line_output = 0
 extra_standard_library = pkg_resources,setuptools,logging,os,warnings,abc
-known_third_party =yaml
+known_third_party = yaml
 no_lines_before = STDLIB,LOCALFOLDER
 default_section = THIRDPARTY


### PR DESCRIPTION
## Motivation

https://github.com/open-mmlab/mmflow/pull/87

Upgrade the version of `isort`.

## Modification

- Remove seed-isort-config in pre-commit hook
- Upgrade isort to v5.10.1 (latest version)
- Replace known_standard_library with extra_standard_library