### PR TITLE
[Feature] Support checking model-index.yml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -26,3 +26,11 @@
   entry: check-copyright
   require_serial: true
   pass_filenames: false
+
+- id: check-model-index
+  name: check model index
+  description: Check whether the model-index.yml conforms to specification
+  language: python
+  entry: check-model-index
+  require_serial: true
+  pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -36,3 +36,19 @@ Check whether the code contains copyright
 - `includes` - directory to add copyright.
 - `--excludes` - exclude directory.
 - `--suffixes` - copyright will be added to files with suffix.
+
+### check-model-index
+
+Check whether the model-index.yml conforms to specification.
+
+- `filename` - model-index file path.
+
+```yaml
+-   repo: https://github.com/open-mmlab/pre-commit-hooks
+    rev: v0.2.1  # Use the ref you want to point at
+    hooks:
+    -   id: check-model-index
+        args: ["model-index.yml"]
+        additional_dependencies:
+          - cerberus
+```

--- a/pre_commit_hooks/check_model_index.py
+++ b/pre_commit_hooks/check_model_index.py
@@ -1,0 +1,348 @@
+import argparse
+import os.path as osp
+from collections import defaultdict
+
+import yaml
+from cerberus import Validator
+
+collection_schema = {
+    'Name': {
+        'type': 'string'
+    },
+    'Metadata': {
+        'type': 'dict',
+        'required': False,
+        'schema': {
+            'Training Data': {
+                'type': ['string', 'list'],
+                'schema': {
+                    'type': 'string'
+                },
+                'required': False,
+            },
+            'Epochs': {
+                'type': 'integer',
+                'required': False,
+            },
+            'Batch Size': {
+                'type': 'integer',
+                'required': False,
+            },
+            'Training Techniques': {
+                'type': 'list',
+                'schema': {
+                    'type': 'string'
+                },
+            },
+            'Training Resources': {
+                'type': 'string',
+                'required': False,
+            },
+            'FLOPs': {
+                'type': 'number',
+                'required': False,
+            },
+            'Parameters': {
+                'type': 'integer',
+                'required': False,
+            },
+            'Train time (s/iter)': {
+                'type': 'number',
+                'required': False,
+            },
+            'Training Memory (GB)': {
+                'type': 'float',
+                'required': False,
+            },
+            'Architecture': {
+                'type': 'list',
+                'required': False,
+                'schema': {
+                    'type': 'string',
+                }
+            }
+        },
+    },
+    'Paper': {
+        'type': 'dict',
+        'required': False,
+        'schema': {
+            'URL': {
+                'type': 'string'
+            },
+            'Title': {
+                'type': 'string'
+            },
+        },
+    },
+    'README': {
+        'type': 'string'
+    },
+    'Weights': {
+        'type': 'string'
+    },
+}
+
+model_schema = {
+    'Name': {
+        'type': 'string'
+    },
+    'In Collection': {
+        'type': 'string',
+        'required': False
+    },
+    'Metadata': {
+        'type': 'dict',
+        'schema': {
+            'Training Data': {
+                'type': ['string', 'list'],
+                'schema': {
+                    'type': 'string'
+                },
+                'required': False,
+            },
+            'Epochs': {
+                'type': 'integer',
+                'required': False,
+            },
+            'Batch Size': {
+                'type': 'integer',
+                'required': False,
+            },
+            'Training Techniques': {
+                'type': 'list',  # ['string', 'list'] may be better
+                'schema': {
+                    'type': 'string'
+                },
+                'required': False,
+            },
+            'Training Resources': {
+                'type': 'string',
+                'required': False,
+            },
+            'FLOPs': {
+                'type': 'number',
+                'required': False,
+            },
+            'Parameters': {
+                'type': 'integer',
+                'required': False,
+            },
+            'Training Time': {
+                'type': 'number',
+                'required': False,
+            },
+            'Train time (s/iter)': {
+                'type': 'number',
+                'required': False,
+            },
+            'Training Memory (GB)': {
+                'type': 'float',
+                'required': False,
+            },
+            'Architecture': {
+                'type': 'list',  # ['string', 'list'] may be better
+                'required': False,
+                'schema': {
+                    'type': 'string',
+                }
+            },
+            'inference time (ms/im)': {
+                'type': 'dict',
+                'required': False,
+                'schema': {
+                    'value': {
+                        'type': 'float',  # 'number' may be better
+                    },
+                    'hardware': {
+                        'type': 'string',
+                    },
+                    'backend': {
+                        'type': 'string',
+                    },
+                    'batch_size': {
+                        'type': 'integer',
+                    },
+                    'mode': {
+                        'type': 'string',
+                    },
+                    'resolution': {
+                        'type': 'list',
+                    }
+                },
+            },
+        },
+    },
+    'Results': {
+        'type': 'list',
+        'schema': {
+            'type': 'string',
+            'schema': {
+                'Task': {
+                    'type': 'string'
+                },
+                'Dataset': {
+                    'type': 'string'
+                },
+                'Metrics': {
+                    'type': 'list',
+                    'schema': {
+                        'type': 'dict',
+                    }
+                }
+            }
+        },
+    },
+    'Config': {
+        'type': 'string'
+    },
+    'Weights': {
+        'type': 'string',
+        'required': False
+    },
+    'Training Log': {
+        'type': 'string',
+        'required': False
+    },
+    'README': {
+        'type': 'string',
+        'required': False
+    },
+    'Paper': {
+        'type': 'dict',
+        'required': False,
+        'schema': {
+            'URL': {
+                'type': 'string',
+                'required': False
+            },
+            'Title': {
+                'type': 'string'
+            },
+        },
+    },
+    'Converted From': {
+        'type': 'dict',
+        'required': False,
+        'schema': {
+            'Weights': {
+                'type': 'string'
+            },
+            'Code': {
+                'type': 'string'
+            },
+        },
+    },
+    'Image': {
+        'type': 'string',
+        'required': False,
+    },
+    'Code': {
+        'type': 'dict',
+        'required': False,
+        'schema': {
+            'URL': {
+                'type': 'string'
+            },
+            'Version': {
+                'type': 'string'
+            }
+        }
+    }
+}
+
+collection_validatetor = Validator(collection_schema)
+model_validatetor = Validator(model_schema)
+
+
+def load_metafile(path: str):
+    if not osp.exists(path):
+        print(f'File "{path}" does not exist.')
+        return None
+
+    with open(path) as f:
+        raw = yaml.load(f, Loader=yaml.SafeLoader)
+
+    return raw
+
+
+def check_model_index(path: str) -> bool:
+    retv = 0
+    error_messages = defaultdict(dict)
+    collection_names = defaultdict(list)
+    model_names = defaultdict(list)
+    model_index_data = load_metafile(path)
+
+    if model_index_data is None or not isinstance(model_index_data, dict):
+        print('Expected the file {path} to contain a dict, '
+              f'but got {model_index_data}')
+        retv = 1
+    else:
+        for metafile_path in model_index_data['Import']:
+            metafile_data = load_metafile(metafile_path)
+
+            error_message = {}
+            if metafile_data is not None:
+                collections = metafile_data.get('Collections')
+                if collections is not None:
+                    for collection in collections:
+                        collection_names[collection['Name']].append(
+                            metafile_path)
+                        if not collection_validatetor.validate(collection):
+                            error_message.setdefault('collections', {})
+                            error_message['collections'][collection[
+                                'Name']] = collection_validatetor.errors
+                            retv = 1
+
+                models = metafile_data.get('Models')
+                if models is not None:
+                    for model in models:
+                        model_names[model['Name']].append(metafile_path)
+                        if not model_validatetor.validate(model):
+                            error_message.setdefault('models', {})
+                            error_message['models'][
+                                model['Name']] = model_validatetor.errors
+                            retv = 1
+
+            else:
+                retv = 1
+
+            if len(error_message) > 0:
+                error_messages[metafile_path] = error_message
+
+    for name, paths in collection_names.items():
+        if len(paths) > 1:
+            print(f'Collection "{name}" is defined in multiple places:')
+            for path in paths:
+                print(f'\t{path}')
+
+            retv = 1
+
+    for name, paths in model_names.items():
+        if len(paths) > 1:
+            print(f'Model "{name}" is defined in multiple places:')
+            for path in paths:
+                print(f'\t{path}')
+
+            retv = 1
+
+    for path, msg in error_messages.items():
+        print(f'\n{path}')
+        for k, v in msg.items():
+            print(f'\t{k}: {v}')
+
+    return retv
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Check model index')
+    parser.add_argument('filename', help='model-index file path')
+    args = parser.parse_args()
+
+    retv = check_model_index(args.filename)
+
+    return retv
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/pre_commit_hooks/check_model_index.py
+++ b/pre_commit_hooks/check_model_index.py
@@ -273,6 +273,7 @@ def check_model_index(path: str) -> bool:
     retv = 0
     error_messages = defaultdict(dict)
     collection_names = defaultdict(list)
+    in_collection_names = set()
     model_names = defaultdict(list)
     model_index_data = load_metafile(path)
 
@@ -300,6 +301,7 @@ def check_model_index(path: str) -> bool:
                 models = metafile_data.get('Models')
                 if models is not None:
                     for model in models:
+                        in_collection_names.add(model['In Collection'])
                         model_names[model['Name']].append(metafile_path)
                         if not model_validatetor.validate(model):
                             error_message.setdefault('models', {})
@@ -328,6 +330,23 @@ def check_model_index(path: str) -> bool:
                 print(f'\t{path}')
 
             retv = 1
+
+    collection_names_set = set(collection_names.keys())
+    if collection_names_set != in_collection_names:
+        print('collection names referred by models should be euqal to '
+              'collection names.')
+
+        different_set = collection_names_set - in_collection_names
+        if different_set:
+            print(
+                f'collection names {different_set} are not referred by models')
+
+        different_set = in_collection_names - collection_names_set
+        if different_set:
+            print(f'collection names {different_set} referred by models but '
+                  'not in collection_names')
+
+        retv = 1
 
     for path, msg in error_messages.items():
         print(f'\n{path}')

--- a/pre_commit_hooks/check_model_index.py
+++ b/pre_commit_hooks/check_model_index.py
@@ -46,6 +46,10 @@ collection_schema = {
                 'type': 'integer',
                 'required': False,
             },
+            'Training Time': {
+                'type': 'number',
+                'required': False,
+            },
             'Train time (s/iter)': {
                 'type': 'number',
                 'required': False,
@@ -89,7 +93,6 @@ model_schema = {
     },
     'In Collection': {
         'type': 'string',
-        'required': False
     },
     'Metadata': {
         'type': 'dict',
@@ -148,27 +151,30 @@ model_schema = {
                 }
             },
             'inference time (ms/im)': {
-                'type': 'dict',
+                'type': 'list',
                 'required': False,
                 'schema': {
-                    'value': {
-                        'type': 'float',  # 'number' may be better
+                    'type': 'dict',
+                    'schema': {
+                        'value': {
+                            'type': 'float',  # 'number' may be better
+                        },
+                        'hardware': {
+                            'type': 'string',
+                        },
+                        'backend': {
+                            'type': 'string',
+                        },
+                        'batch size': {
+                            'type': 'integer',
+                        },
+                        'mode': {
+                            'type': 'string',
+                        },
+                        'resolution': {
+                            'type': 'list',
+                        }
                     },
-                    'hardware': {
-                        'type': 'string',
-                    },
-                    'backend': {
-                        'type': 'string',
-                    },
-                    'batch_size': {
-                        'type': 'integer',
-                    },
-                    'mode': {
-                        'type': 'string',
-                    },
-                    'resolution': {
-                        'type': 'list',
-                    }
                 },
             },
         },
@@ -176,7 +182,7 @@ model_schema = {
     'Results': {
         'type': 'list',
         'schema': {
-            'type': 'string',
+            'type': 'dict',
             'schema': {
                 'Task': {
                     'type': 'string'
@@ -185,10 +191,7 @@ model_schema = {
                     'type': 'string'
                 },
                 'Metrics': {
-                    'type': 'list',
-                    'schema': {
-                        'type': 'dict',
-                    }
+                    'type': 'dict',
                 }
             }
         },

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
             'say-hello=pre_commit_hooks.say_hello:main',
             'check-algo-readme=pre_commit_hooks.check_algo_readme:main',
             'check-copyright=pre_commit_hooks.check_copyright:main',
+            'check-model-index=pre_commit_hooks.check_model_index:main',
         ],
     },
 )


### PR DESCRIPTION
Modify `.pre-commit-config.yaml` with the following config to test this hook.

```yaml
  - repo: https://github.com/zhouzaida/pre-commit-hooks-1
    rev: 0672dd0  # Use the ref you want to point at
    hooks:
      - id: check-model-index
        args: ["model-index.yml"]  # replace the dir_to_check with your expected directory to check
        additional_dependencies:
          - cerberus
 ```


In addition, since YAML does not support tuple type, the resolution field in a metafile is recognized as a string, so fix this type to be a list. You can use the following regular expression global replacement in vs code

- `resolution: \(([0-9]*), ([0-9]*)\)`
- `resolution: [$1, $2]`

![image](https://user-images.githubusercontent.com/58739961/179392999-d43bf6b5-b922-4337-b57d-5221502aa431.png)

