### PR TITLE
Add an option to allow files can not be found

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Check whether the code contains copyright
 - `includes` - directory to add copyright.
 - `--excludes` - exclude directory.
 - `--suffixes` - copyright will be added to files with suffix.
+- `--ignore_file_not_found_error` - Whether to ignore `FileNotFoundError` when some directories are specified to add copyright but they are not found.
 
 ### check-ecosystem-validity
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Check whether the code contains copyright
 - `includes` - directory to add copyright.
 - `--excludes` - exclude directory.
 - `--suffixes` - copyright will be added to files with suffix.
-- `--ignore_file_not_found_error` - Whether to ignore `FileNotFoundError` when some directories are specified to add copyright but they are not found.
+- `--ignore-file-not-found-error` - Whether to ignore `FileNotFoundError` when some directories are specified to add copyright but they are not found.
 
 ### check-ecosystem-validity
 

--- a/pre_commit_hooks/check_copyright.py
+++ b/pre_commit_hooks/check_copyright.py
@@ -51,14 +51,18 @@ def check_args(includes: List[str],
 
     # check the correctness and format args
     for i, dir in enumerate(includes):
-        if not osp.exists(dir) and not ignore_file_not_found_error:
-            raise FileNotFoundError(f'Include {dir} can not be found')
-        includes[i] = osp.abspath(dir)
+        if not osp.exists(dir):
+            if not ignore_file_not_found_error:
+                raise FileNotFoundError(f'Include {dir} can not be found')
+        else:
+            includes[i] = osp.abspath(dir)
 
     for i, dir in enumerate(excludes):
-        if not osp.exists(dir) and not ignore_file_not_found_error:
-            raise FileNotFoundError(f'Exclude {dir} can not be found')
-        excludes[i] = osp.abspath(dir)
+        if not osp.exists(dir):
+            if not ignore_file_not_found_error:
+                raise FileNotFoundError(f'Exclude {dir} can not be found')
+        else:
+            excludes[i] = osp.abspath(dir)
 
     for suffix in suffixes:
         if suffix not in valid_suffixes:

--- a/pre_commit_hooks/check_copyright.py
+++ b/pre_commit_hooks/check_copyright.py
@@ -53,14 +53,14 @@ def check_args(includes: List[str],
     for i, dir in enumerate(includes):
         if not osp.exists(dir):
             if not ignore_file_not_found_error:
-                raise FileNotFoundError(f'Include {dir} can not be found')
+                raise FileNotFoundError(f'{dir} can not be found')
         else:
             includes[i] = osp.abspath(dir)
 
     for i, dir in enumerate(excludes):
         if not osp.exists(dir):
             if not ignore_file_not_found_error:
-                raise FileNotFoundError(f'Exclude {dir} can not be found')
+                raise FileNotFoundError(f'{dir} can not be found')
         else:
             excludes[i] = osp.abspath(dir)
 


### PR DESCRIPTION
Modify `.pre-commit-config.yaml` with the following config to test this hook.

```yaml
  - repo: https://github.com/zhouzaida/pre-commit-hooks-1
    rev: 8dd4395  # Use the ref you want to point at
    hooks:
    -   id: check-copyright
        args: ["dir_to_check", "not-found-dir", "--ignore-file-not-found-error"] 
 ```