### PR TITLE
[Feature] Add remove_eol_characters hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -41,7 +41,7 @@
 - id: remove-improper-eol-in-cn-docs
   name: remove improper eol in cn docs
   description: Remove the end_of_line characters that split natural paragraphs in Chinese docs
-  entry: remove_eol_characters
+  entry: remove-eol-characters
   language: python
   files: .*\.md$
   pass_filenames: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -37,3 +37,12 @@
   pass_filenames: false
   additional_dependencies:
   - cerberus
+
+- id: remove-improper-eol-in-cn-docs
+  name: remove improper eol in cn docs
+  description: Remove the end_of_line characters that split natural paragraphs in Chinese docs
+  entry: remove_eol_characters
+  language: python
+  files: .*\.md$
+  pass_filenames: true
+  require_serial: true

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Add this to your `.pre-commit-config.yaml`
         args: [projects_index.yaml]
         additional_dependencies:
           - cerberus
+    -   id: remove-improper-eol-in-cn-docs
 ```
 
 ## Hooks available
@@ -55,4 +56,27 @@ Check the validity of the ecosystem yaml file
         args: [projects_index.yaml]
         additional_dependencies:
           - cerberus
+```
+
+### remove-improper-eol-in-cn-docs
+
+Remove end-of-line characters that split natural paragraphs in Chinese docs.
+
+This helps resolve extra whitespaces in Chinese Markdown docs described [here](https://stackoverflow.com/questions/8550112/prevent-workaround-browser-converting-n-between-lines-into-space-for-chinese/8551033#8551033), as a long-standing HTML rendering issue. For example,
+
+> 这是一个，
+> 像诗一样的
+> 测试
+
+will be changed to:
+
+> 这是一个，像诗一样的测试
+
+Usage:
+
+```yaml
+  - repo: https://github.com/open-mmlab/pre-commit-hooks
+    rev: v0.3.0
+    hooks:
+    -   id: remove-improper-eol-in-cn-docs
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Add this to your `.pre-commit-config.yaml`
 
 ```yaml
 -   repo: https://github.com/open-mmlab/pre-commit-hooks
-    rev: v0.3.0  # Use the ref you want to point at
+    rev: v0.4.0  # Use the ref you want to point at
     hooks:
     -   id: check-algo-readme
     -   id: check-copyright
@@ -50,7 +50,7 @@ Check the validity of the ecosystem yaml file
 
 ```yaml
   - repo: https://github.com/open-mmlab/pre-commit-hooks
-    rev: v0.3.0
+    rev: v0.4.0
     hooks:
     -   id: check-ecosystem-validity
         args: [projects_index.yaml]
@@ -76,7 +76,7 @@ Usage:
 
 ```yaml
   - repo: https://github.com/open-mmlab/pre-commit-hooks
-    rev: v0.3.0
+    rev: v0.4.0
     hooks:
     -   id: remove-improper-eol-in-cn-docs
 ```

--- a/pre_commit_hooks/remove_eol_characters.py
+++ b/pre_commit_hooks/remove_eol_characters.py
@@ -37,9 +37,13 @@ def rewrite_file(file_name: str, strategies: List[Tuple[str, str]]) -> bool:
     return changed
 
 
-if __name__ == '__main__':
+def main():
     strategies = [remove_eol()]
     changed = False
     for file in sys.argv[1:]:
         changed = changed | rewrite_file(file, strategies)
-    sys.exit(changed)
+    return changed
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/pre_commit_hooks/remove_eol_characters.py
+++ b/pre_commit_hooks/remove_eol_characters.py
@@ -1,6 +1,5 @@
 #! /usr/bin/env python
 
-import codecs
 import re
 import sys
 from typing import List, Tuple
@@ -23,7 +22,7 @@ def remove_eol() -> Tuple[str, str]:
 
 
 def rewrite_file(file_name: str, strategies: List[Tuple[str, str]]) -> bool:
-    with codecs.open(file_name, mode='r', encoding='utf-8') as f:
+    with open(file_name, encoding='utf-8') as f:
         contents = f.read()
     changed = False
     for pattern, repl in strategies:
@@ -32,7 +31,7 @@ def rewrite_file(file_name: str, strategies: List[Tuple[str, str]]) -> bool:
         contents = re.sub(pattern, repl, contents)
         changed = True
     if changed:
-        with codecs.open(file_name, mode='w', encoding='utf-8') as f:
+        with open(file_name, mode='w', encoding='utf-8') as f:
             f.write(contents)
     return changed
 

--- a/pre_commit_hooks/remove_eol_characters.py
+++ b/pre_commit_hooks/remove_eol_characters.py
@@ -1,0 +1,45 @@
+#! /usr/bin/env python
+
+import codecs
+import re
+import sys
+from typing import List, Tuple
+
+
+def remove_eol() -> Tuple[str, str]:
+    eol_character = r'\n'
+    # \u4e00-\u9fff contains all chinese characters
+    characters = r'\u4e00-\u9fff'
+    # Unicode halfwidth and fullwidth forms, refer to
+    # https://en.wikipedia.org/wiki/Halfwidth_and_Fullwidth_Forms_(Unicode_block)
+    punctuations = r'\uff01-\uff9f'
+    # Find natural Chinese paragraphs that are split by end_of_line characters.
+    # The pattern is: Chinese characters/punctuations with one and only one
+    # end_of_line in between.
+    pattern = fr'([{characters}{punctuations}]){eol_character}([{characters}])'
+    # This replacement will remove the end_of_line character in between
+    repl = r'\1\2'
+    return pattern, repl
+
+
+def rewrite_file(file_name: str, strategies: List[Tuple[str, str]]) -> bool:
+    with codecs.open(file_name, mode='r', encoding='utf-8') as f:
+        contents = f.read()
+    changed = False
+    for pattern, repl in strategies:
+        if re.search(pattern, contents) is None:
+            continue
+        contents = re.sub(pattern, repl, contents)
+        changed = True
+    if changed:
+        with codecs.open(file_name, mode='w', encoding='utf-8') as f:
+            f.write(contents)
+    return changed
+
+
+if __name__ == '__main__':
+    strategies = [remove_eol()]
+    changed = False
+    for file in sys.argv[1:]:
+        changed = changed | rewrite_file(file, strategies)
+    sys.exit(changed)

--- a/pre_commit_hooks/remove_eol_characters.py
+++ b/pre_commit_hooks/remove_eol_characters.py
@@ -21,8 +21,8 @@ def remove_eol() -> Tuple[str, str]:
     return pattern, repl
 
 
-def rewrite_file(file_name: str, strategies: List[Tuple[str, str]]) -> bool:
-    with open(file_name, encoding='utf-8') as f:
+def rewrite_file(filename: str, strategies: List[Tuple[str, str]]) -> bool:
+    with open(filename, encoding='utf-8') as f:
         contents = f.read()
     changed = False
     for pattern, repl in strategies:
@@ -31,7 +31,7 @@ def rewrite_file(file_name: str, strategies: List[Tuple[str, str]]) -> bool:
         contents = re.sub(pattern, repl, contents)
         changed = True
     if changed:
-        with open(file_name, mode='w', encoding='utf-8') as f:
+        with open(filename, mode='w', encoding='utf-8') as f:
             f.write(contents)
     return changed
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
             'say-hello=pre_commit_hooks.say_hello:main',
             'check-algo-readme=pre_commit_hooks.check_algo_readme:main',
             'check-copyright=pre_commit_hooks.check_copyright:main',
-            'check-ecosystem-validity=pre_commit_hooks.check_ecosystem_validity:main'  # noqa: E501
+            'check-ecosystem-validity=pre_commit_hooks.check_ecosystem_validity:main',  # noqa: E501
             'remove-eol-characters=pre_commit_hooks.remove_eol_characters:main'
         ],
     },

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme():
 
 setup(
     name='pre_commit_hooks',
-    version='0.3.0',
+    version='0.4.0',
     description='A pre-commit hook for OpenMMLab projects',
     long_description=readme(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
             'check-algo-readme=pre_commit_hooks.check_algo_readme:main',
             'check-copyright=pre_commit_hooks.check_copyright:main',
             'check-ecosystem-validity=pre_commit_hooks.check_ecosystem_validity:main'  # noqa: E501
+            'remove-eol-characters=pre_commit_hooks.remove_eol_characters:main'
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme():
 
 setup(
     name='pre_commit_hooks',
-    version='0.4.0',
+    version='0.3.0',
     description='A pre-commit hook for OpenMMLab projects',
     long_description=readme(),
     long_description_content_type='text/markdown',

--- a/tests/test_remove_eol_characters.py
+++ b/tests/test_remove_eol_characters.py
@@ -1,13 +1,11 @@
-import codecs
-
 from pre_commit_hooks.remove_eol_characters import remove_eol, rewrite_file
 
-wrong_text = """这是一个，
+original_text = """这是一个，
 测试。
 This is a
 test
 """
-correct_text = """这是一个，测试。
+rewrote_text = """这是一个，测试。
 This is a
 test
 """
@@ -15,10 +13,10 @@ test
 
 def test_remove_eol_characters(tmp_path):
     file_path = str(tmp_path / 'test.md')
-    with codecs.open(file_path, mode='w', encoding='utf-8') as f:
-        f.write(wrong_text)
+    with open(file_path, mode='w', encoding='utf-8') as f:
+        f.write(original_text)
     strategies = [remove_eol()]
     assert rewrite_file(file_path, strategies)
-    with codecs.open(file_path, 'r', encoding='utf-8') as f:
+    with open(file_path, encoding='utf-8') as f:
         contents = f.read()
-    assert contents == correct_text
+    assert contents == rewrote_text

--- a/tests/test_remove_eol_characters.py
+++ b/tests/test_remove_eol_characters.py
@@ -1,0 +1,24 @@
+import codecs
+
+from pre_commit_hooks.remove_eol_characters import remove_eol, rewrite_file
+
+wrong_text = """这是一个，
+测试。
+This is a
+test
+"""
+correct_text = """这是一个，测试。
+This is a
+test
+"""
+
+
+def test_remove_eol_characters(tmp_path):
+    file_path = str(tmp_path / 'test.md')
+    with codecs.open(file_path, mode='w', encoding='utf-8') as f:
+        f.write(wrong_text)
+    strategies = [remove_eol()]
+    assert rewrite_file(file_path, strategies)
+    with codecs.open(file_path, 'r', encoding='utf-8') as f:
+        contents = f.read()
+    assert contents == correct_text


### PR DESCRIPTION
This PR adds a new script/pre-commit-hook, named `remove-improper-eol-in-cn-docs`.

The script aims at resolving extra whitespaces in Chinese docs, which is a long-standing HTML issue as discussed [here](https://stackoverflow.com/questions/8550112/prevent-workaround-browser-converting-n-between-lines-into-space-for-chinese/8551033#8551033).

To solve the issue, this script finds and removes end_of_line characters which split natural Chinese paragraphs. For example,

> 这是一个，
> 像诗一样的
> 测试

will be changed to

> 这是一个，像诗一样的测试

However, the following cases stay unchanged:
- Docs written in English
> This is,
> a poem-like
> test
- Natural paragraphs (split by 2+ eol characters in Markdown)
> 这是一个
> 
> 测试